### PR TITLE
Updated Lynx Parser Reference and Remove Hints as Objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "mocha --recursive test",
+    "test": "mocha test --recursive --compilers js:babel-register --require babel-polyfill",
     "build": "babel node_modules/jsua/src -d node_modules/jsua/lib && babel src -d lib"
   },
   "keywords": [
@@ -29,6 +29,6 @@
   },
   "dependencies": {
     "jsua": "github:lynx-json/jsua",
-    "lynx-parser": "github:johnhowes/lynx-parser"
+    "lynx-parser": "github:lynx-json/lynx-parser"
   }
 }

--- a/src/builders/node-view-builder.js
+++ b/src/builders/node-view-builder.js
@@ -13,7 +13,7 @@ export function nodeViewBuilder(node) {
   if (!node.spec.hints || node.spec.hints.length === 0) return Promise.reject(new Error("'hints' property not found or zero length."));
   
   var input = !!node.spec.input;
-  var hints = node.spec.hints.map(hint => hint.name);
+  var hints = node.spec.hints;
   var builder = resolver.resolveViewBuilder(building.registrations, hints, input);
   
   if (!builder) return Promise.reject(new Error("No builder registered for node with input=" + input + " and hints=" + hints.join(",")));
@@ -26,7 +26,7 @@ export function nodeViewBuilder(node) {
       reject(e);
     }
   }).then(function (view) {
-    view.setAttribute("data-lynx-hints", node.spec.hints.map(hint => hint.name).join(" "));
+    view.setAttribute("data-lynx-hints", node.spec.hints.join(" "));
     if (node.spec.visibility) view.setAttribute("data-lynx-visibility", node.spec.visibility);
     if (node.spec.name) view.setAttribute("data-lynx-name", node.spec.name);
     if (hasScope(node)) view.setAttribute("data-lynx-scope", node.value.scope);

--- a/test/builders/node-view-builder.js
+++ b/test/builders/node-view-builder.js
@@ -49,7 +49,7 @@ describe("builders / nodeViewBuilder", function () {
     var resolveViewBuilderStub = sinon.stub(resolver, "resolveViewBuilder");
     resolveViewBuilderStub.returns(null);
     
-    return builders.nodeViewBuilder({ spec: { hints: [ { name: "text" } ] } }).catch(function (err) {
+    return builders.nodeViewBuilder({ spec: { hints: [ "text" ] } }).catch(function (err) {
       resolveViewBuilderStub.called.should.be.true;
       resolveViewBuilderStub.restore();
       throw err;
@@ -63,7 +63,7 @@ describe("builders / nodeViewBuilder", function () {
       spec: { 
         name: "node1",
         visibility: "visible",
-        hints: [ { name: "group" }, { name: "container" } ],
+        hints: [ "group", "container" ],
         labeledBy: "node2"
       },
       value: {
@@ -73,7 +73,7 @@ describe("builders / nodeViewBuilder", function () {
     
     return runTest(node, function (view) {
       expect(view).to.not.be.null;
-      view.getAttribute("data-lynx-hints").should.equal(node.spec.hints.map(hint => hint.name).join(" "));
+      view.getAttribute("data-lynx-hints").should.equal(node.spec.hints.join(" "));
       view.getAttribute("data-lynx-visibility").should.equal(node.spec.visibility);
       view.getAttribute("data-lynx-scope").should.equal(node.value.scope);
       view.getAttribute("data-lynx-name").should.equal(node.spec.name);
@@ -132,7 +132,7 @@ describe("builders / nodeViewBuilder", function () {
     var node = { 
       spec: { 
         name: "node1",
-        hints: [ { name: "text" } ],
+        hints: [ "text" ],
         submitter: "node2"
       },
       value: {}

--- a/test/building/index.js
+++ b/test/building/index.js
@@ -1,6 +1,6 @@
 require("../html-document-api");
-var building = require("../../lib/building");
-var builders = require("../../lib/builders");
+var building = require("../../src/building");
+var builders = require("../../src/builders");
 var chai = require("chai");
 var should = chai.should();
 var expect = chai.expect;

--- a/test/building/index.js
+++ b/test/building/index.js
@@ -1,6 +1,6 @@
 require("../html-document-api");
-var building = require("../../src/building");
-var builders = require("../../src/builders");
+var building = require("../../lib/building");
+var builders = require("../../lib/builders");
 var chai = require("chai");
 var should = chai.should();
 var expect = chai.expect;

--- a/test/html-document-api.js
+++ b/test/html-document-api.js
@@ -1,7 +1,7 @@
-if (typeof window !== "undefined") return;
-
-var jsdom = require("jsdom").jsdom;
-global.document = jsdom();
-global.window = document.defaultView;
-global.Blob = window.Blob;
-global.FileReader = window.FileReader;
+if (typeof window === "undefined") {
+  var jsdom = require("jsdom").jsdom;
+  global.document = jsdom();
+  global.window = document.defaultView;
+  global.Blob = window.Blob;
+  global.FileReader = window.FileReader;
+}


### PR DESCRIPTION
Per change to lynx spec to remove support for hints as objects.