### PR TITLE
Add Support for Link Follow

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ A view representing a node of a Lynx JSON document may have the following attrib
 * `data-lynx-scope` - the node's `scope` (`container` nodes)
 * `href` - the node's `href` property value (`link` nodes)
 * `type` - the node's `type` property value (`link` nodes)
-* `data-lynx-follow` - the node's `follow` property value (`link` nodes)
 * `data-lynx-input` - the node's input name for form data submission
 * `data-lynx-options` - the node's `options` property value (input nodes)
 * `data-lynx-submitter` - the node's `submitter` property value (`form` and input nodes)

--- a/src/builders/link-view-builder.js
+++ b/src/builders/link-view-builder.js
@@ -13,10 +13,14 @@ export function linkViewBuilder(node) {
   
   view.type = node.value.type;
   
-  if (node.value.follow !== undefined) {
-    view.setAttribute("data-lynx-follow", node.value.follow);
-  } else if (node.spec.follow !== undefined) {
-    view.setAttribute("data-lynx-follow", node.spec.follow);
+  var followTimeout = tryGetFollowTimeoutForFollowValue(node);
+  
+  if (followTimeout) {
+    view.addEventListener("jsua-attach", function () {
+      setTimeout(function () {
+        view.click();
+      }, followTimeout);
+    });
   }
   
   view.addEventListener("click", function (evt) {
@@ -35,4 +39,12 @@ export function linkViewBuilder(node) {
       
       return view;
     });
+}
+
+function tryGetFollowTimeoutForFollowValue(node) {
+  console.log(node.value.follow);
+  var follow = +node.value.follow;
+  if (isNaN(follow)) follow = +node.spec.follow;
+  if (isNaN(follow)) return;
+  return follow < 10 ? 10 : follow;
 }

--- a/src/builders/link-view-builder.js
+++ b/src/builders/link-view-builder.js
@@ -13,7 +13,7 @@ export function linkViewBuilder(node) {
   
   view.type = node.value.type;
   
-  var followTimeout = tryGetFollowTimeoutForFollowValue(node);
+  var followTimeout = tryGetFollowTimeout(node);
   
   if (followTimeout) {
     view.addEventListener("jsua-attach", function () {
@@ -41,7 +41,7 @@ export function linkViewBuilder(node) {
     });
 }
 
-function tryGetFollowTimeoutForFollowValue(node) {
+function tryGetFollowTimeout(node) {
   console.log(node.value.follow);
   var follow = +node.value.follow;
   if (isNaN(follow)) follow = +node.spec.follow;

--- a/test/builders/link-view-builder.js
+++ b/test/builders/link-view-builder.js
@@ -52,24 +52,6 @@ describe("builders / linkViewBuilder", function () {
     });
   });
   
-  it("should set attribute 'follow' when on value", function () {
-    node.value.follow = 0;
-    
-    return links.linkViewBuilder(node).then(function (view) {
-      expect(view).to.not.equal(null);
-      view.getAttribute("data-lynx-follow").should.equal("0");
-    });
-  });
-  
-  it("should set attribute 'follow' when on spec", function () {
-    node.spec.follow = 0;
-    
-    return links.linkViewBuilder(node).then(function (view) {
-      expect(view).to.not.equal(null);
-      view.getAttribute("data-lynx-follow").should.equal("0");
-    });
-  });
-  
   it("should resolve the 'href' if a 'base' URI is present", function () {
     node.base = "http://example.com";
     
@@ -88,6 +70,36 @@ describe("builders / linkViewBuilder", function () {
     
     afterEach(function () {
       fetchStub.restore();
+    });
+    
+    it("should click link when value has 'follow' property", function () {
+      node.value.follow = 0;
+      
+      return new Promise(function (resolve) {
+        links.linkViewBuilder(node).then(function (view) {
+          view.addEventListener("click", function () {
+            expect(fetchStub.calledOnce).to.equal(true);
+            resolve();
+          });
+          
+          view.dispatchEvent(new CustomEvent("jsua-attach"));
+        });
+      });
+    });
+    
+    it("should click link when spec has 'follow' property", function () {
+      node.spec.follow = 0;
+      
+      return new Promise(function (resolve) {
+        links.linkViewBuilder(node).then(function (view) {
+          view.addEventListener("click", function () {
+            expect(fetchStub.calledOnce).to.equal(true);
+            resolve();
+          });
+          
+          view.dispatchEvent(new CustomEvent("jsua-attach"));
+        });
+      });
     });
     
     it("should fetch", function () {


### PR DESCRIPTION
This PR adds support for the link's `follow` attribute by starting a
timer after the view has been attached and clicks the link when the
timeout function is called.