### PR TITLE
Add Content Type to Transfer Options

### DIFF
--- a/test/builders/content-view-builder.js
+++ b/test/builders/content-view-builder.js
@@ -42,7 +42,7 @@ describe("builders / contentViewBuilder", function () {
       view.children.length.should.equal(1);
       view.children.item(0).getAttribute("alt").should.equal(node.value.alt);
       transferStub.called.should.be.true;
-      transferStub.lastCall.args[0].should.deep.equal({ url: "http://example.com/foo" });
+      transferStub.lastCall.args[0].should.deep.equal({ url: "http://example.com/foo", options: { type: "text/plain" } });
       buildStub.called.should.be.true;
     });
   });

--- a/test/builders/link-view-builder.js
+++ b/test/builders/link-view-builder.js
@@ -81,32 +81,38 @@ describe("builders / linkViewBuilder", function () {
       fetchStub.restore();
     });
     
-    it("should click link when value has 'follow' property", function () {
+    it("should fetch when value has 'follow' property", function () {
       node.value.follow = 0;
       
       return new Promise(function (resolve) {
-        links.linkViewBuilder(node).then(function (view) {
-          view.addEventListener("click", function () {
-            expect(fetchStub.calledOnce).to.equal(true);
-            resolve();
-          });
-          
+        links.linkViewBuilder(node).then(function (view) {          
           view.dispatchEvent(new CustomEvent("jsua-attach"));
+          
+          setTimeout(function () {
+            if (fetchStub.calledOnce) {
+              resolve();
+            } else {
+              reject(new Error("fetch was not called"));
+            }
+          }, 20);
         });
       });
     });
     
-    it("should click link when spec has 'follow' property", function () {
+    it("should fetch when spec has 'follow' property", function () {
       node.spec.follow = 0;
       
-      return new Promise(function (resolve) {
+      return new Promise(function (resolve, reject) {
         links.linkViewBuilder(node).then(function (view) {
-          view.addEventListener("click", function () {
-            expect(fetchStub.calledOnce).to.equal(true);
-            resolve();
-          });
-          
           view.dispatchEvent(new CustomEvent("jsua-attach"));
+          
+          setTimeout(function () {
+            if (fetchStub.calledOnce) {
+              resolve();
+            } else {
+              reject(new Error("fetch was not called"));
+            }
+          }, 20);
         });
       });
     });


### PR DESCRIPTION
Adding the non-authoritative content type from the content node to the transferring request.options object in order to support user agent customizations that want to rely on this information for optimizations.