### PR TITLE
Access to validation constraint set object

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ A view representing a node of a Lynx JSON document may have the following method
 * `lynxRemoveValue` - removes a value from a container input view
 * `lynxValidateValue` - if the view can be validated, performs the validation
 * `lynxGetValidationState` - if the view can be validated, gets the validation state of the view
+* `lynxGetValidationConstraintSetObject` - gets the normalized validation constraint set of a view
 * `lynxGetConcealView` - gets the view that represents the conceal action of a view
 * `lynxSetConcealView` - sets the view that represents the conceal action of a view
 * `lynxGetRevealView` - gets the view that represents the reveal action of a view

--- a/src/builders/validation/index.js
+++ b/src/builders/validation/index.js
@@ -24,8 +24,6 @@ export function updateContentTargetVisibility(origin, constraint) {
 export function addValidationExtensionsToView(view, validation) {
   exports.normalizeValidationConstraintSetObject(validation);
 
-  if (validation.required) view.setAttribute("data-lynx-validation-required", true);
-
   if (view.matches("[data-lynx-input]")) {
     exports.addValidationExtensionsToInputView(view, validation);
   } else {

--- a/src/builders/validation/index.js
+++ b/src/builders/validation/index.js
@@ -101,6 +101,10 @@ export function addValidationExtensionsToInputView(view, validation) {
     return view.getAttribute("data-lynx-validation-state");
   };
 
+  view.lynxGetValidationConstraintSetObject = function () {
+    return validation;
+  };
+
   view.lynxValidateValue = function () {
     var value = view.lynxGetValue();
     exports.validateValue(validation, value);

--- a/test/builders/validation/index.js
+++ b/test/builders/validation/index.js
@@ -325,6 +325,11 @@ describe("validation / addValidationExtensionsToInputView", function () {
     view.getAttribute("data-lynx-validation-state").should.equal("invalid");
   });
 
+  it("should allow access to validation contstraint set object", function () {
+    validation.addValidationExtensionsToInputView(view, validationObj);
+    view.lynxGetValidationConstraintSetObject().should.equal(validationObj);
+  });
+
   it("should set 'data-lynx-validation-state' attribute and raise event when validity state changes", function () {
     validation.addValidationExtensionsToInputView(view, validationObj);
     var changeListener = view.addEventListener.getCall(0).args[1];

--- a/test/builders/validation/index.js
+++ b/test/builders/validation/index.js
@@ -242,25 +242,6 @@ describe("validation / normalizeValidationConstraintSetObject", function () {
 });
 
 describe("validation / addValidationExtensionsToView", function () {
-  it("should add 'data-lynx-validation-required' to view if validation.required exists", function () {
-    var view = {},
-      validationObj = { required: { invalid: "invalidMessage" } };
-    view.setAttribute = function (name, value) {
-      view[name] = value;
-    };
-
-    view.matches = function () { return true; };
-    var stubs = [
-      sinon.stub(validation, "normalizeValidationConstraintSetObject"),
-      sinon.stub(validation, "addValidationExtensionsToInputView")
-    ];
-
-    validation.addValidationExtensionsToView(view, validationObj);
-    stubs.forEach(stub => stub.restore());
-
-    expect(view["data-lynx-validation-required"]).to.equal(true);
-  });
-
   it("should call the appropriate funcs for input views", function () {
     var view = {},
       validationObj = {};


### PR DESCRIPTION
This change is to expose access to the normalized validation constraint set object for an input view that has validation. Because access is now provided to this object, we no longer needed `data-lynx-validation-required` on an input view with validation.required so I removed that statement and supporting test as well.