### PR TITLE
Fine tuning number.step validation

### DIFF
--- a/src/builders/validation/validators.js
+++ b/src/builders/validation/validators.js
@@ -1,3 +1,11 @@
+const decimalPattern = /\.(\d*)$/;
+
+function getDecimalPlaces(value) {
+  let result = decimalPattern.exec(value);
+  if (!result || !result[1]) return 0;
+  return result[1].length;
+}
+
 export function noopValidator() {
   return "unknown";
 }
@@ -15,7 +23,7 @@ export function createRegExpForTextConstraintPattern(pattern) {
 
 export function textValidator(constraint, value) {
   var empty = (value === undefined || value === null || value === "");
-  
+
   if (empty) {
     return "valid";
   }
@@ -36,33 +44,36 @@ export function textValidator(constraint, value) {
       return "invalid";
     }
   }
-  
+
   return "valid";
 }
 
 export function numberValidator(constraint, value) {
   var empty = (value === undefined || value === null || value === "");
-  
+
   if (empty) {
     return "valid";
   }
 
-  if(isNaN(+value)){
+  if (isNaN(+value)) {
     return "invalid";
   }
 
-  if (constraint.min && (value < Number(constraint.min))) {
+  if (constraint.min && (+value < +constraint.min)) {
     return "invalid";
   }
 
-  if (constraint.max && (value > Number(constraint.max))) {
+  if (constraint.max && (+value > +constraint.max)) {
     return "invalid";
   }
 
-  if (constraint.step && (value % Number(constraint.step) !== 0)) {
-    return "invalid";
+  if (constraint.step) {
+    let stepDecimals = getDecimalPlaces(constraint.step);
+    let valueDecimals = getDecimalPlaces(value);
+    if (valueDecimals > stepDecimals) return "invalid";
+    if (+(+value % +constraint.step).toFixed(stepDecimals) !== 0) return "invalid";
   }
-  
+
   return "valid";
 }
 
@@ -76,26 +87,26 @@ export function typeMatchesTypeRange(actualType, expectedTypeRange) {
 
 export function contentValidator(constraint, value) {
   var empty = (value === null || value.length === 0);
-  
+
   if (empty) {
     return "valid";
   }
-  
+
   if (constraint.type) {
     var expectedTypeRanges = constraint.type;
-    
+
     if (!Array.isArray(expectedTypeRanges)) {
-      expectedTypeRanges = [ expectedTypeRanges ];
+      expectedTypeRanges = [expectedTypeRanges];
     }
-    
+
     var matchesTypeRange = typeMatchesTypeRange.bind(null, value.type);
-    
+
     if (!expectedTypeRanges.some(matchesTypeRange)) return "invalid";
   }
-  
+
   if (constraint.maxLength && value.length > constraint.maxLength) {
     return "invalid";
   }
-  
+
   return "valid";
 }

--- a/src/builders/validation/validators.js
+++ b/src/builders/validation/validators.js
@@ -70,7 +70,7 @@ export function numberValidator(constraint, value) {
   if (constraint.step) {
     let decimals = Math.max(getDecimalPlaces(constraint.step), getDecimalPlaces(value));
     let multiplier = decimals === 0 ? 1 : +("1" + "0".repeat(decimals));
-    if (((+value * multiplier) % (+constraint.step * multiplier)) !== 0) return "invalid";
+    if ((+(+value * multiplier).toFixed(0) % +(+constraint.step * multiplier).toFixed(0)) !== 0) return "invalid";
   }
 
   return "valid";

--- a/src/builders/validation/validators.js
+++ b/src/builders/validation/validators.js
@@ -1,7 +1,7 @@
 const decimalPattern = /\.(\d*)$/;
 
 function getDecimalPlaces(value) {
-  let result = decimalPattern.exec(value);
+  let result = decimalPattern.exec(value.toString());
   if (!result || !result[1]) return 0;
   return result[1].length;
 }
@@ -68,10 +68,9 @@ export function numberValidator(constraint, value) {
   }
 
   if (constraint.step) {
-    let stepDecimals = getDecimalPlaces(constraint.step);
-    let valueDecimals = getDecimalPlaces(value);
-    if (valueDecimals > stepDecimals) return "invalid";
-    if (+(+value % +constraint.step).toFixed(stepDecimals) !== 0) return "invalid";
+    let decimals = Math.max(getDecimalPlaces(constraint.step), getDecimalPlaces(value));
+    let multiplier = decimals === 0 ? 1 : +("1" + "0".repeat(decimals));
+    if (((+value * multiplier) % (+constraint.step * multiplier)) !== 0) return "invalid";
   }
 
   return "valid";

--- a/test/builders/validation/validators.js
+++ b/test/builders/validation/validators.js
@@ -152,17 +152,30 @@ describe("validators / numberValidator", function () {
     validators.numberValidator(constraint, "15").should.equal("invalid");
   });
 
-  it("should return 'valid' when value is divisible by 'step' when accounting for significant digits", function () {
+  it("should return 'valid' when decimal value is divisible by 'step' when simple remainder would fail", function () {
     var constraint = { step: 0.01 };
     var value = "0.34";
-    (+value % constraint.step).should.not.equal(0);
+    (+value % constraint.step).should.not.equal(0); //To indicate that remainder won't suffice
     validators.numberValidator(constraint, value).should.equal("valid");
   });
 
-  it("should return 'invalid' when value has more decimals than 'step' ", function () {
+  it("should return 'valid' when decimal value is divisible by 'step' when multiplication and simple remainder would fail", function () {
+    var constraint = { step: 0.01 };
+    var value = "0.07";
+    ((+value * 100) % (constraint.step * 100)).should.not.equal(0); //To indicate that multiplication plus remainder won't suffice
+    validators.numberValidator(constraint, value).should.equal("valid");
+  });
+
+  it("should return 'invalid' when decimal value is not divisible by 'step'", function () {
     var constraint = { step: 0.01 };
     var value = "0.34001";
     validators.numberValidator(constraint, value).should.equal("invalid");
+  });
+
+  it("should return 'valid' when decimal value is divisible by 'step'", function () {
+    var constraint = { step: 0.01 };
+    var value = "0.34000";
+    validators.numberValidator(constraint, value).should.equal("valid");
   });
 });
 

--- a/test/builders/validation/validators.js
+++ b/test/builders/validation/validators.js
@@ -17,22 +17,22 @@ describe("validators / requiredValidator", function () {
     var constraint = {};
     validators.requiredValidator(constraint).should.equal("invalid");
   });
-  
+
   it("should return 'invalid' when value is null", function () {
     var constraint = {};
     validators.requiredValidator(constraint, null).should.equal("invalid");
   });
-  
+
   it("should return 'invalid' when value is an empty string", function () {
     var constraint = {};
     validators.requiredValidator(constraint, "").should.equal("invalid");
   });
-  
+
   it("should return 'invalid' when value is an empty array", function () {
     var constraint = {};
     validators.requiredValidator(constraint, []).should.equal("invalid");
   });
-  
+
   it("should return 'valid' when value is a non-empty string", function () {
     var constraint = {};
     validators.requiredValidator(constraint, "testing").should.equal("valid");
@@ -44,52 +44,52 @@ describe("validators / textValidator", function () {
     var constraint = { maxLength: 2 };
     validators.textValidator(constraint).should.equal("valid");
   });
-  
+
   it("should return 'valid' when value is null", function () {
     var constraint = { maxLength: 2 };
     validators.textValidator(constraint, null).should.equal("valid");
   });
-  
+
   it("should return 'valid' when value is an empty string", function () {
     var constraint = { maxLength: 2 };
     validators.textValidator(constraint, "").should.equal("valid");
   });
-  
+
   it("should return 'invalid' when value length is less than 'minLength'", function () {
     var constraint = { minLength: 4 };
     validators.textValidator(constraint, "Joe").should.equal("invalid");
   });
-  
+
   it("should return 'valid' when value length is equal to 'minLength'", function () {
     var constraint = { minLength: 4 };
     validators.textValidator(constraint, "Joel").should.equal("valid");
   });
-  
+
   it("should return 'valid' when value length is more than 'minLength'", function () {
     var constraint = { minLength: 4 };
     validators.textValidator(constraint, "Joelene").should.equal("valid");
   });
-  
+
   it("should return 'valid' when value length is less than 'maxLength'", function () {
     var constraint = { maxLength: 4 };
     validators.textValidator(constraint, "Joe").should.equal("valid");
   });
-  
+
   it("should return 'valid' when value length is equal to 'maxLength'", function () {
     var constraint = { maxLength: 4 };
     validators.textValidator(constraint, "Joel").should.equal("valid");
   });
-  
+
   it("should return 'invalid' when value length is more than 'maxLength'", function () {
     var constraint = { maxLength: 4 };
     validators.textValidator(constraint, "Joelene").should.equal("invalid");
   });
-  
+
   it("should return 'invalid' when value does not match 'pattern'", function () {
     var constraint = { pattern: "\\d*" };
     validators.textValidator(constraint, "ABCDE").should.equal("invalid");
   });
-  
+
   it("should return 'valid' when value matches 'pattern'", function () {
     var constraint = { pattern: "\\d*" };
     validators.textValidator(constraint, "12345").should.equal("valid");
@@ -101,55 +101,68 @@ describe("validators / numberValidator", function () {
     var constraint = { max: 2 };
     validators.numberValidator(constraint).should.equal("valid");
   });
-  
+
   it("should return 'valid' when value is null", function () {
     var constraint = { max: 2 };
     validators.numberValidator(constraint, null).should.equal("valid");
   });
-  
+
   it("should return 'valid' when value is an empty string", function () {
     var constraint = { max: 2 };
     validators.numberValidator(constraint, "").should.equal("valid");
   });
-  
+
   it("should return 'invalid' when value is less than 'min'", function () {
     var constraint = { min: 10 };
     validators.numberValidator(constraint, "5").should.equal("invalid");
   });
-  
+
   it("should return 'valid' when value is equal to 'min'", function () {
     var constraint = { min: 10 };
     validators.numberValidator(constraint, "10").should.equal("valid");
   });
-  
+
   it("should return 'valid' when value is more than 'min'", function () {
     var constraint = { min: 10 };
     validators.numberValidator(constraint, "15").should.equal("valid");
   });
-  
+
   it("should return 'valid' when value is less than 'max'", function () {
     var constraint = { max: 10 };
     validators.numberValidator(constraint, "5").should.equal("valid");
   });
-  
+
   it("should return 'valid' when value is equal to 'max'", function () {
     var constraint = { max: 10 };
     validators.numberValidator(constraint, "10").should.equal("valid");
   });
-  
+
   it("should return 'invalid' when value is more than 'max'", function () {
     var constraint = { max: 10 };
     validators.numberValidator(constraint, "15").should.equal("invalid");
   });
-  
+
   it("should return 'valid' when value is divisible by 'step'", function () {
     var constraint = { step: 7 };
     validators.numberValidator(constraint, "14").should.equal("valid");
   });
-  
+
   it("should return 'invalid' when value is not divisible by 'step'", function () {
     var constraint = { step: 7 };
     validators.numberValidator(constraint, "15").should.equal("invalid");
+  });
+
+  it("should return 'valid' when value is divisible by 'step' when accounting for significant digits", function () {
+    var constraint = { step: 0.01 };
+    var value = "0.34";
+    (+value % constraint.step).should.not.equal(0);
+    validators.numberValidator(constraint, value).should.equal("valid");
+  });
+
+  it("should return 'invalid' when value has more decimals than 'step' ", function () {
+    var constraint = { step: 0.01 };
+    var value = "0.34001";
+    validators.numberValidator(constraint, value).should.equal("invalid");
   });
 });
 
@@ -157,19 +170,19 @@ describe("validators / typeMatchesTypeRange", function () {
   it("should return true when exact match", function () {
     validators.typeMatchesTypeRange("text/plain", "text/plain").should.be.true;
   });
-  
+
   it("should return true when type range contains parameters", function () {
     validators.typeMatchesTypeRange("text/plain", "text/plain;charset=utf-8").should.be.true;
   });
-  
+
   it("should return true when media type matches type range", function () {
     validators.typeMatchesTypeRange("text/plain", "text/*").should.be.true;
   });
-  
+
   it("should return true when media type contains parameters", function () {
     validators.typeMatchesTypeRange("text/plain;charset=utf-8", "text/*").should.be.true;
   });
-  
+
   it("should return true when media type matches global type range", function () {
     validators.typeMatchesTypeRange("text/plain", "*/*").should.be.true;
   });
@@ -180,39 +193,39 @@ describe("validators / contentValidator", function () {
     var constraint = { type: "image/*" };
     validators.contentValidator(constraint, { type: "image/jpeg" }).should.equal("valid");
   });
-  
+
   it("should return 'valid' when value's media type matches array of type range", function () {
-    var constraint = { type: [ "text/*", "image/*" ] };
+    var constraint = { type: ["text/*", "image/*"] };
     validators.contentValidator(constraint, { type: "image/jpeg" }).should.equal("valid");
   });
-  
+
   it("should return 'valid' when value's media type matches type", function () {
     var constraint = { type: "image/jpeg" };
     validators.contentValidator(constraint, { type: "image/jpeg" }).should.equal("valid");
   });
-  
+
   it("should return 'valid' when value's media type matches array of types", function () {
-    var constraint = { type: [ "image/jpeg", "image/png" ] };
+    var constraint = { type: ["image/jpeg", "image/png"] };
     validators.contentValidator(constraint, { type: "image/jpeg" }).should.equal("valid");
   });
-  
+
   it("should return 'invalid' when value's media type does not match type range", function () {
     var constraint = { type: "video/*" };
     validators.contentValidator(constraint, { type: "image/jpeg" }).should.equal("invalid");
   });
-  
+
   it("should return 'invalid' when value's media type does not match array of type range", function () {
-    var constraint = { type: [ "text/*", "image/*" ] };
+    var constraint = { type: ["text/*", "image/*"] };
     validators.contentValidator(constraint, { type: "video/ogg" }).should.equal("invalid");
   });
-  
+
   it("should return 'invalid' when value's media type does not match type", function () {
     var constraint = { type: "image/jpeg" };
     validators.contentValidator(constraint, { type: "image/png" }).should.equal("invalid");
   });
-  
+
   it("should return 'invalid' when value's media type does not match array of types", function () {
-    var constraint = { type: [ "image/jpeg", "image/png" ] };
+    var constraint = { type: ["image/jpeg", "image/png"] };
     validators.contentValidator(constraint, { type: "video/ogg" }).should.equal("invalid");
   });
 });


### PR DESCRIPTION
The number.step validation logic did not take into account significant
digits when calculating validation state. The original calculation
was a simple remainder calculation that would produce inaccurate results
for some floating point situations. For example a `step` of `0.01`
evaluated against a value of `0.34` would result in `invalid` even
though it is a valid step. This change adds logic to use the number of
decimal places in the `step` value to determine significant digits for
evaluating the result of the remainder calculation. If the value has
more decimal digits than the step `invalid` is the result.