### PR TITLE
Implemented, documented, tested building.setNodeViewBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Extensions to the `jsua` package for the Lynx JSON media type.
 
 `building.registrations` returns the registrations added via `building.register`
 
+`building.setNodeViewBuilder` sets the default nodeViewBuilder, accepting a function with signature f(node) -> view || Promise<view>
+
 ## View Attributes
 
 A view representing a Lynx JSON document may have the following attributes:

--- a/src/builders/container-input-view-builder.js
+++ b/src/builders/container-input-view-builder.js
@@ -1,15 +1,15 @@
 import * as containers from "./container-view-builder";
-import { nodeViewBuilder } from "./node-view-builder";
+import * as nodes from "./node-view-builder";
 
 export function containerInputViewBuilder(node) {
   function appendChildView(childView) {
     childView.setAttribute("data-lynx-container-input-value", true);
-    
+
     var itemView = document.createElement("div");
     view.appendChild(itemView);
     itemView.setAttribute("data-lynx-container-input-item", true);
     itemView.appendChild(childView);
-    
+
     var removeView = document.createElement("button");
     itemView.appendChild(removeView);
     removeView.setAttribute("data-lynx-container-input-remove", true);
@@ -19,12 +19,12 @@ export function containerInputViewBuilder(node) {
       view.removeChild(itemView);
       raiseValueChangeEvent(view);
     });
-    
+
     return itemView;
   }
-  
+
   var view = document.createElement("div");
-  
+
   var addView = document.createElement("button");
   view.appendChild(addView);
   addView.setAttribute("data-lynx-container-input-add", true);
@@ -33,50 +33,50 @@ export function containerInputViewBuilder(node) {
   addView.addEventListener("click", function () {
     view.lynxAddValue();
   });
-  
+
   view.lynxAddValue = function (val) {
     function initializeChildNode() {
       var childNode = {
         base: node.base,
         spec: JSON.parse(JSON.stringify(node.spec.children))
       };
-      
+
       if (!val) {
         childNode.value = null;
         return Promise.resolve(childNode);
       }
-      
+
       if (childNode.spec.hints.some(hint => hint === "text")) {
         childNode.value = val;
         return Promise.resolve(childNode);
       }
-      
+
       if (childNode.spec.hints.some(hint => hint === "content")) {
         return new Promise(function (resolve) {
           var reader = new FileReader();
-          
+
           reader.onload = function () {
             childNode.value = {
               src: reader.result
             };
             resolve(childNode);
           };
-          
+
           reader.onerror = function () {
             childNode.value = null;
             resolve(childNode);
           };
-          
+
           reader.readAsDataURL(val);
         });
       }
-      
+
       childNode.value = null;
       return Promise.resolve(childNode);
     }
-    
+
     return initializeChildNode()
-      .then(nodeViewBuilder)
+      .then(nodes.nodeViewBuilder)
       .then(appendChildView)
       .then(function (itemView) {
         raiseValueChangeEvent(view);
@@ -86,44 +86,44 @@ export function containerInputViewBuilder(node) {
         console.log("Error adding value to container input.", err);
       });
   };
-  
+
   view.lynxRemoveValue = function (val) {
     var valueToRemove = val || "";
-    
+
     var itemViewsToRemove = Array.from(view.querySelectorAll("[data-lynx-container-input-value]"))
       .filter(valueView => valueToRemove === valueView.lynxGetValue())
       .map(valueView => valueView.parentElement);
-      
+
     if (itemViewsToRemove.length === 0) return;
     itemViewsToRemove.forEach(itemView => itemView.parentElement.removeChild(itemView));
     raiseValueChangeEvent(view);
   };
-  
+
   view.lynxGetValue = function () {
     return Array.from(view.querySelectorAll("[data-lynx-container-input-value]"))
       .map(valueView => valueView.lynxGetValue());
   };
-  
+
   view.lynxSetValue = function (values) {
     view.lynxClearValue();
     if (!values) return;
-    
+
     if (!Array.isArray(values)) values = [values];
     values.forEach(value => view.lynxAddValue(value));
   };
-  
+
   view.lynxHasValue = function (val) {
     var valueViews = Array.from(view.querySelectorAll("[data-lynx-container-input-value]"));
     var promisesForHasValue = valueViews.map(valueView => valueView.lynxHasValue(val));
     return Promise.all(promisesForHasValue)
       .then(hasValues => hasValues.some(hasValue => hasValue));
   };
-  
+
   view.lynxClearValue = function () {
     Array.from(view.querySelectorAll("[data-lynx-container-input-item]"))
       .forEach(itemView => itemView.parentElement.removeChild(itemView));
   };
-  
+
   return containers.buildChildViews(node)
     .then(function (childViews) {
       childViews.forEach(appendChildView);
@@ -135,7 +135,7 @@ function raiseValueChangeEvent(view) {
   var inputEvent = document.createEvent("Event");
   inputEvent.initEvent("input", true, false);
   view.dispatchEvent(inputEvent);
-  
+
   var changeEvent = document.createEvent("Event");
   changeEvent.initEvent("change", true, false);
   view.dispatchEvent(changeEvent);

--- a/src/builders/index.js
+++ b/src/builders/index.js
@@ -1,5 +1,5 @@
 import { resolveViewBuilder } from "./resolve-view-builder";
-import { nodeViewBuilder } from "./node-view-builder";
+import * as nodes from "./node-view-builder";
 import { textViewBuilder } from "./text-view-builder";
 import { textInputViewBuilder } from "./text-input-view-builder";
 import { containerViewBuilder } from "./container-view-builder";
@@ -11,7 +11,9 @@ import { contentInputViewBuilder } from "./content-input-view-builder";
 import { linkViewBuilder } from "./link-view-builder";
 import { submitViewBuilder } from "./submit-view-builder";
 
-export { 
+var nodeViewBuilder = nodes.nodeViewBuilder;
+
+export {
   resolveViewBuilder,
   nodeViewBuilder,
   textViewBuilder,

--- a/src/building/index.js
+++ b/src/building/index.js
@@ -1,6 +1,7 @@
 import * as LYNX from "@lynx-json/lynx-parser";
 import * as builders from "../builders";
 import * as util from "../util";
+import * as nodes from "../builders/node-view-builder";
 
 export var registrations = [];
 
@@ -58,4 +59,8 @@ export function documentViewBuilder(content) {
     if (content.options.document.focus) view.setAttribute("data-lynx-focus", content.options.document.focus);
     return view;
   });
+}
+
+export function setNodeViewBuilder(builder) {
+  builders.nodeViewBuilder = nodes.nodeViewBuilder = builder;
 }

--- a/src/building/index.js
+++ b/src/building/index.js
@@ -62,5 +62,5 @@ export function documentViewBuilder(content) {
 }
 
 export function setNodeViewBuilder(builder) {
-  builders.nodeViewBuilder = nodes.nodeViewBuilder = builder;
+  nodes.nodeViewBuilder = builder;
 }

--- a/test/building/index.js
+++ b/test/building/index.js
@@ -241,10 +241,7 @@ describe("building", function () {
       building.setNodeViewBuilder(originalNodeViewBuilder);
     });
 
-    it("should set builders.nodeViewBuilder to the builder parameter", function () {
-      builders.nodeViewBuilder({}).test.should.equal(true);
-
-      // Internally, view builders import the "node-view-builders" module directly.
+    it("should set the internal nodeViewBuilder to the builder parameter", function () {
       nodes.nodeViewBuilder({}).test.should.equal(true);
     });
   });

--- a/test/building/index.js
+++ b/test/building/index.js
@@ -1,6 +1,7 @@
 require("../html-document-api");
 var building = require("../../dist/building");
 var builders = require("../../dist/builders");
+var nodes = require("../../dist/builders/node-view-builder");
 var chai = require("chai");
 var should = chai.should();
 var expect = chai.expect;
@@ -61,7 +62,7 @@ describe("building", function () {
       building.registrations[0].builder.should.equal(builder);
       expect(building.registrations[0].condition).to.equal(undefined);
     });
-    
+
     it("should record registrations with condition", function () {
       var hint = "text";
       var builder = function () {};
@@ -220,6 +221,31 @@ describe("building", function () {
           expect(view).to.not.be.null;
           view.getAttribute("data-lynx-focus").should.equal(node.focus);
         });
+    });
+  });
+
+  describe("setNodeViewBuilder", function () {
+    var originalNodeViewBuilder = builders.nodeViewBuilder;
+
+    function newNodeViewBuilder(node) {
+      return {
+        test: true
+      };
+    }
+
+    beforeEach(function () {
+      building.setNodeViewBuilder(newNodeViewBuilder);
+    });
+
+    afterEach(function() {
+      building.setNodeViewBuilder(originalNodeViewBuilder);
+    });
+
+    it("should set builders.nodeViewBuilder to the builder parameter", function () {
+      builders.nodeViewBuilder({}).test.should.equal(true);
+
+      // Internally, view builders import the "node-view-builders" module directly.
+      nodes.nodeViewBuilder({}).test.should.equal(true);
     });
   });
 });


### PR DESCRIPTION
The intention is to allow overriding the default `nodeViewBuilder` to allow including additional information on the view based on attributes of the node. The immediate use case is to convert a spec extension to a data property on the view.