### PR TITLE
Change validation content visibility before firing event

### DIFF
--- a/src/builders/validation/index.js
+++ b/src/builders/validation/index.js
@@ -66,8 +66,8 @@ export function addValidationExtensionsToContainerView(view, validation) {
     exports.validateContainer(view, validation);
 
     if (validation.state !== validation.priorState) {
-      view.setAttribute("data-lynx-validation-state", validation.state);
       view.lynxUpdateValidationContentVisibility();
+      view.setAttribute("data-lynx-validation-state", validation.state);
       exports.raiseValidationStateChangedEvent(view, validation);
     }
   });

--- a/src/builders/validation/index.js
+++ b/src/builders/validation/index.js
@@ -67,8 +67,8 @@ export function addValidationExtensionsToContainerView(view, validation) {
 
     if (validation.state !== validation.priorState) {
       view.setAttribute("data-lynx-validation-state", validation.state);
-      exports.raiseValidationStateChangedEvent(view, validation);
       view.lynxUpdateValidationContentVisibility();
+      exports.raiseValidationStateChangedEvent(view, validation);
     }
   });
 
@@ -107,13 +107,14 @@ export function addValidationExtensionsToInputView(view, validation) {
     var value = view.lynxGetValue();
     exports.validateValue(validation, value);
 
+    if(validation.changes.length > 0) view.lynxUpdateValidationContentVisibility();
+
     if (validation.state !== validation.priorState) {
       view.setAttribute("data-lynx-validation-state", validation.state);
       exports.raiseValidationStateChangedEvent(view, validation);
     }
 
     if (validation.changes.length > 0) {
-      view.lynxUpdateValidationContentVisibility();
       let formattedConstraint = validation.changes.find(isFormattedConstraint);
       if (formattedConstraint) view.lynxSetValue(exports.formatValue(formattedConstraint, view.lynxGetValue()));
     }


### PR DESCRIPTION
This proposed change is to update the visibility of related validation content before dispatching the `lynx-validation-state-change` event. This allows components to make determinations on positioning of the validation content when responding to the `lynx-validation-state-change` event. Without this change, the visibility of the validation content has not been updated so there is not enough information to make those determinations in the `lynx-validation-state-change` event handlers.