### PR TITLE
Support changes to `scope`

### DIFF
--- a/src/attaching.js
+++ b/src/attaching.js
@@ -13,9 +13,10 @@ export function scopeRealmAttacher(result) {
   if (exports.isOutOfContext(origin, context)) return { discard: true };
 
   var realm = view.getAttribute("data-lynx-realm");
-  if (!realm) return;
+  var contentUrl = view.getAttribute("data-content-url");
 
-  var nearestContentView = exports.findNearestScopedContentView(origin, realm);
+  var nearestContentView = exports.findNearestScopedContentView(origin, contentUrl) || exports.findNearestScopedContentView(origin, realm);
+
   if (!nearestContentView) return;
 
   if (resultIsStale(result, nearestContentView)) return { discard: true };
@@ -102,6 +103,8 @@ export function isDetached(view) {
 }
 
 export function findNearestScopedContentView(origin, realm) {
+  if (!realm) return null;
+
   return util.findNearestView(origin, "[data-lynx-hints~=content][data-lynx-scope]", function (matching) {
     var scope = matching.getAttribute("data-lynx-scope");
     return util.scopeIncludesRealm(scope, realm);

--- a/src/builders/image-view-builder.js
+++ b/src/builders/image-view-builder.js
@@ -1,6 +1,7 @@
 import url from "url";
 import { contentViewBuilder } from "./content-view-builder";
 import { getBlob } from "./content-node-helpers";
+import * as util from "../util";
 
 function applyImageAttributes(node) {
   return function (view) {
@@ -35,7 +36,7 @@ function buildAsEmbeddedImageTag(node) {
   return contentViewBuilder(emptyNode)
     .then(function (view) {
       var imageView = document.createElement("img");
-      imageView.src = url.resolve(node.base || "", node.value.src);
+      imageView.src = util.resolveUrlForNode(node, node.value.src);
       imageView.setAttribute("data-content-url", imageView.src);
       imageView.setAttribute("data-content-type", node.value.type);
       view.lynxSetEmbeddedView(imageView, new Blob([], { type: node.value.type }));

--- a/src/builders/link-view-builder.js
+++ b/src/builders/link-view-builder.js
@@ -1,37 +1,38 @@
 import * as containers from "./container-view-builder";
 import url from "url";
+import * as util from "../util";
 import { fetch } from "@lynx-json/jsua";
 
 export function createDataUri(link) {
   var contentType = link.type;
   var encoding = link.encoding || "utf-8";
-  
+
   if (encoding !== "utf-8" && encoding !== "base64") throw new Error("The 'encoding' property value for a link must be 'utf-8' or 'base64'.");
-  
+
   var dataUri = "data:" + contentType;
-  
+
   if (encoding === "base64") {
     dataUri += ";base64,";
   } else {
     dataUri += ",";
   }
-  
+
   if (encoding === "utf-8" && typeof link.data !== "string") {
     dataUri += JSON.stringify(link.data);
   } else {
     dataUri += link.data;
   }
-  
+
   return dataUri;
 }
 
 export function getHref(node) {
   var link = node.value;
-  
+
   if ("data" in link) {
     // data
     if (!link.type) throw new Error("A link with a 'data' property must have a valid 'type' property.");
-    
+
     if (link.type.indexOf("application/lynx+json") > -1) {
       return "lynx:?ts=" + new Date().valueOf();
     } else {
@@ -39,35 +40,31 @@ export function getHref(node) {
     }
   } else {
     // href
-    if (node.base) {
-      return url.resolve(node.base, link.href);
-    } else {
-      return link.href;
-    }
+    return util.resolveUrlForNode(node, link.href);
   }
 }
 
 export function linkViewBuilder(node) {
   var view = document.createElement("a");
   var followTimerId;
-  
+
   view.href = getHref(node);
   if (node.value.type) view.type = node.value.type;
-  
+
   var followTimeout = tryGetFollowTimeout(node);
-  
+
   function getOptions(automatic) {
     var options = { origin: view };
-    
+
     if (automatic) options.automatic = true;
-    
+
     if (view.protocol === "lynx:") {
       options.document = node.value.data;
     }
-    
+
     return options;
   }
-  
+
   if (followTimeout) {
     view.addEventListener("jsua-attach", function () {
       followTimerId = setTimeout(function () {
@@ -75,22 +72,22 @@ export function linkViewBuilder(node) {
       }, followTimeout);
     });
   }
-  
+
   view.addEventListener("click", function (evt) {
     evt.preventDefault();
     evt.stopPropagation();
     if (followTimerId) clearTimeout(followTimerId);
     fetch(view.href, getOptions());
   });
-  
+
   return containers.buildChildViews(node)
     .then(function (childViews) {
       childViews.forEach(childView => view.appendChild(childView));
-      
+
       if (view.children.length === 0) {
         view.textContent = view.href;
       }
-      
+
       return view;
     });
 }

--- a/src/builders/node-view-builder.js
+++ b/src/builders/node-view-builder.js
@@ -2,17 +2,10 @@ import * as resolver from "./resolve-view-builder";
 import * as validation from "./validation";
 import * as options from "./options";
 import * as util from "../util";
-import url from "url";
 
 var registrations;
 export function setRegistrations(r) {
   registrations = r;
-}
-
-function hasScope(node) {
-  return node.value &&
-    typeof node.value === "object" &&
-    "scope" in node.value;
 }
 
 function didNotUnderstandNodeViewBuilder(node) {
@@ -48,7 +41,6 @@ export function nodeViewBuilder(node) {
       }
     }
 
-    if (hasScope(node)) view.setAttribute("data-lynx-scope", util.resolveUrlForNode(node, node.value.scope));
     if (!!node.spec.input) view.setAttribute("data-lynx-input", node.spec.input);
     if (node.spec.labeledBy) view.setAttribute("data-lynx-labeled-by", node.spec.labeledBy);
     if (node.spec.submitter) addSubmitterExtensionsToView(view, node.spec.submitter);

--- a/src/builders/node-view-builder.js
+++ b/src/builders/node-view-builder.js
@@ -44,11 +44,11 @@ export function nodeViewBuilder(node) {
       view.setAttribute("data-lynx-name", node.spec.name);
       var fragmentComponent = "#" + node.spec.name;
       if (node.base) {
-        view.setAttribute("data-jsua-view-uri", url.resolve(node.base, fragmentComponent));
+        view.setAttribute("data-jsua-view-uri", util.resolveUrlForNode(node, fragmentComponent));
       }
     }
 
-    if (hasScope(node)) view.setAttribute("data-lynx-scope", node.value.scope);
+    if (hasScope(node)) view.setAttribute("data-lynx-scope", util.resolveUrlForNode(node, node.value.scope));
     if (!!node.spec.input) view.setAttribute("data-lynx-input", node.spec.input);
     if (node.spec.labeledBy) view.setAttribute("data-lynx-labeled-by", node.spec.labeledBy);
     if (node.spec.submitter) addSubmitterExtensionsToView(view, node.spec.submitter);
@@ -56,7 +56,7 @@ export function nodeViewBuilder(node) {
     if (node.spec.option) view.setAttribute("data-lynx-option", "true");
     if (node.spec.options) options.addOptionsExtensionsToView(view, node.spec);
     if (node.spec.hints.indexOf("marker") > -1 && node.value && node.value.for) {
-      view.setAttribute("data-lynx-marker-for", url.resolve(node.base, node.value.for));
+      view.setAttribute("data-lynx-marker-for", util.resolveUrlForNode(node, node.value.for));
     }
 
     if (node.value && typeof node.value === "object" && !Array.isArray(node.value)) {

--- a/src/builders/submit-view-builder.js
+++ b/src/builders/submit-view-builder.js
@@ -6,11 +6,7 @@ import { fetch } from "@lynx-json/jsua";
 export function submitViewBuilder(node) {
   var view = document.createElement("button");
 
-  if (node.base) {
-    view.formAction = url.resolve(node.base, node.value.action);
-  } else {
-    view.formAction = node.value.action;
-  }
+  view.formAction = util.resolveUrlForNode(node, node.value.action);
 
   if (node.value.method) view.setAttribute("data-lynx-submit-method", node.value.method);
   if (node.value.enctype) view.setAttribute("data-lynx-submit-enctype", node.value.enctype);

--- a/src/util.js
+++ b/src/util.js
@@ -84,3 +84,7 @@ export function scopeIncludesRealm(scope, realm) {
   realm = url.parse(realm).href;
   return realm.indexOf(scope) === 0;
 }
+
+export function resolveUrlForNode(node, relativeOrAbsoluteUrl) {
+  return url.resolve(node.base || '', relativeOrAbsoluteUrl);
+}

--- a/test/attaching.js
+++ b/test/attaching.js
@@ -47,7 +47,23 @@ describe("attaching / scopeRealmAttacher", function () {
     findNearestScopedContentViewStub.restore();
   });
 
-  it("should attach to a scoped content view", function () {
+  it("should attach to a scoped content view with realm", function () {
+    var attachment = attaching.scopeRealmAttacher(result);
+
+    expect(attachment).to.not.equal(undefined);
+    expect(attachment.attach).to.not.equal(undefined);
+    attachment.attach();
+
+    expect(nearestContentView.lynxSetEmbeddedView.calledOnce).to.equal(true);
+    var args = nearestContentView.lynxSetEmbeddedView.getCall(0).args;
+    expect(args[0]).to.equal(result.view);
+    expect(args[1]).to.equal(result.content.blob);
+  });
+
+  it("should attach to a scoped content view with content url", function () {
+    result.view.setAttribute("data-content-url", "http://example.com/foo/");
+    result.view.removeAttribute("data-lynx-realm");
+
     var attachment = attaching.scopeRealmAttacher(result);
 
     expect(attachment).to.not.equal(undefined);

--- a/test/builders/content-view-builder.js
+++ b/test/builders/content-view-builder.js
@@ -43,14 +43,62 @@ describe("builders / contentViewBuilder", function () {
       view.children.length.should.equal(1);
       view.children.item(0).getAttribute("alt").should.equal(node.value.alt);
       transferStub.called.should.be.true;
-      transferStub.lastCall.args[0].should.deep.equal({ 
-        url: "http://example.com/foo", 
-        options: { 
-          type: "text/plain", 
-          media: "screen" 
-        } 
+      transferStub.lastCall.args[0].should.deep.equal({
+        url: "http://example.com/foo",
+        options: {
+          type: "text/plain",
+          media: "screen"
+        }
       });
       buildStub.called.should.be.true;
+    });
+  });
+
+  it("should set resolved scope attribute for objects with relative scope", function () {
+    var node = {
+      base: "http://example.com",
+      spec: {
+        hints: [{ name: "content" }]
+      },
+      value: {
+        scope: "/foo",
+        src: "/foo/doc",
+        type: "text/plain",
+        alt: "An important doc"
+      }
+    };
+
+    transferStub.returns(Promise.resolve({ blob: {} }));
+
+    buildStub.returns(Promise.resolve({ view: document.createElement("div"), content: { blob: {} } }));
+
+    return contents.contentViewBuilder(node).then(function (view) {
+      expect(view).to.not.be.null;
+      expect(view.getAttribute("data-lynx-scope")).to.eq("http://example.com/foo");
+    });
+  });
+
+  it("should set resolved scope attribute for objects with absolute scope", function () {
+    var node = {
+      base: "http://example.com",
+      spec: {
+        hints: [{ name: "content" }]
+      },
+      value: {
+        scope: "http://another.domain.com/foo",
+        src: "/foo/doc",
+        type: "text/plain",
+        alt: "An important doc"
+      }
+    };
+
+    transferStub.returns(Promise.resolve({ blob: {} }));
+
+    buildStub.returns(Promise.resolve({ view: document.createElement("div"), content: { blob: {} } }));
+
+    return contents.contentViewBuilder(node).then(function (view) {
+      expect(view).to.not.be.null;
+      expect(view.getAttribute("data-lynx-scope")).to.eq("http://another.domain.com/foo");
     });
   });
 

--- a/test/builders/node-view-builder.js
+++ b/test/builders/node-view-builder.js
@@ -411,22 +411,4 @@ describe("builders / nodeViewBuilder", function () {
       expect('http://example.com/foo').to.equal(view.getAttribute('data-lynx-marker-for'));
     });
   });
-
-  it("should set resolved scope attribute for objects with scope", function () {
-    var node = {
-      base: 'http://example.com/',
-      spec: {
-        hints: ['content']
-      },
-      value: {
-        scope: '/foo'
-      }
-    };
-
-    return runTest(node, function (view) {
-      expect(view).to.not.equal(null);
-      expect('http://example.com/foo').to.equal(view.getAttribute('data-lynx-scope'));
-    });
-  });
-
 });

--- a/test/builders/node-view-builder.js
+++ b/test/builders/node-view-builder.js
@@ -395,5 +395,38 @@ describe("builders / nodeViewBuilder", function () {
     });
   });
 
-  it("should resolve for attribute for markers");
+  it("should set resolved for attribute for markers", function () {
+    var node = {
+      base: 'http://example.com/',
+      spec: {
+        hints: ['marker', 'container']
+      },
+      value: {
+        for: '/foo'
+      }
+    };
+
+    return runTest(node, function (view) {
+      expect(view).to.not.equal(null);
+      expect('http://example.com/foo').to.equal(view.getAttribute('data-lynx-marker-for'));
+    });
+  });
+
+  it("should set resolved scope attribute for objects with scope", function () {
+    var node = {
+      base: 'http://example.com/',
+      spec: {
+        hints: ['content']
+      },
+      value: {
+        scope: '/foo'
+      }
+    };
+
+    return runTest(node, function (view) {
+      expect(view).to.not.equal(null);
+      expect('http://example.com/foo').to.equal(view.getAttribute('data-lynx-scope'));
+    });
+  });
+
 });


### PR DESCRIPTION
This PR includes two changes.
- Updates to support the changes to the `scope` format rules for `content` objects.
- Centralize the calculation of URLs based on values in a node.

Not sure of the reason for the whitespace churn on link-view-builder.js. Looks like the editor chose to swap whitespace characters.